### PR TITLE
Adding handling for TURN server redirection. 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -478,6 +478,9 @@ async fn main() -> Result<(), Error> {
                 Shutdown => {
                     MessageToTurnServer::Disconnect
                 },
+                TurnEvent(Ok(RedirectedToAlternateServer(sa))) => {
+                    anyhow::bail!("TURN server redirected to alternate server address {}", sa);
+                },
                 TurnEvent(Err(e)) => {
                     eprintln!("{}", e);
                     MessageToTurnServer::Noop


### PR DESCRIPTION
This handling will bail, and print the alternate server address. Future handling could follow the redirect.